### PR TITLE
json: Replace Intel Media SDK to OneVPL Runtime and enable qsv

### DIFF
--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -599,7 +599,7 @@
             ]
         },
         {
-            "name": "mediasdk",
+            "name": "intel-onevpl-rutime",
             "skip-arches": [
                 "aarch64"
             ],
@@ -616,13 +616,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/Intel-Media-SDK/MediaSDK/archive/intel-mediasdk-23.2.2.tar.gz",
-                    "sha256": "12f23a78104edc1c9bfa755effd2723866d107ad752f72d3839fcc8db0503cec",
+                    "url": "https://github.com/oneapi-src/oneVPL-intel-gpu/archive/intel-onevpl-23.3.4.tar.gz",
+                    "sha256": "9de6bfd17259b7434f2bb4fb6d2874decf9b1d4587ec9b90d91188049921e32f",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 21814,
                         "stable-only": true,
-                        "url-template": "https://github.com/Intel-Media-SDK/MediaSDK/archive/intel-mediasdk-$version.tar.gz"
+                        "url-template": "https://github.com/oneapi-src/oneVPL-intel-gpu/archive/intel-onevpl-$version.tar.gz"
                     }
                 }
             ]
@@ -691,7 +691,8 @@
                 "--enable-rpath",
                 "--enable-shared",
                 "--enable-vaapi",
-                "--enable-vdpau"
+                "--enable-vdpau",
+                "--enable-qsv"
             ],
             "build-options": {
                 "prepend-path": "/usr/lib/sdk/llvm15/bin",


### PR DESCRIPTION
Replace Legacy and Dropped Intel Media SDK to use the new OneVPL Runtime from OneAPI. Enable QSV plugin in FFmpeg build