### PR TITLE
MR: Fix Binutils Build using a ffmpeg-binutils var

### DIFF
--- a/ffmpeg-binutils-2.41.patch
+++ b/ffmpeg-binutils-2.41.patch
@@ -1,0 +1,74 @@
+From cc703cf60759d9798f440a9417e4efa2fcbe2747 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
+Date: Sun, 16 Jul 2023 18:18:02 +0300
+Subject: [PATCH] avcodec/x86/mathops: clip constants used with shift
+ instructions within inline assembly
+
+Fixes assembling with binutil as >= 2.41
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+(cherry picked from commit effadce6c756247ea8bae32dc13bb3e6f464f0eb)
+---
+ libavcodec/x86/mathops.h | 26 +++++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+index 6298f5ed1983..ca7e2dffc107 100644
+--- a/libavcodec/x86/mathops.h
++++ b/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 

--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -737,6 +737,10 @@
                         "stable-only": true,
                         "url-template": "https://www.ffmpeg.org/releases/ffmpeg-$version.tar.xz"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "ffmpeg-binutils-2.41.patch"
                 }
             ]
         },

--- a/org.kde.kdenlive.json
+++ b/org.kde.kdenlive.json
@@ -715,19 +715,6 @@
             "build-options": {
                 "prepend-path": "/usr/lib/sdk/llvm17/bin",
                 "prepend-ld-library-path": "/usr/lib/sdk/llvm17/lib",
-                "ldflags": "-fuse-ld=lld",
-                "env": {
-                    "AR": "llvm-ar",
-                    "AS": "llvm-as",
-                    "CC": "clang",
-                    "CXX": "clang++",
-                    "RANLIB": "llvm-ranlib",
-                    "LD": "lld",
-                    "CC_LD": "lld",
-                    "CXX_LD": "lld",
-                    "NM": "llvm-nm",
-                    "STRIP": "llvm-strip"
-                },
                 "arch": {
                     "x86_64": {
                         "config-opts": [


### PR DESCRIPTION
For some whatever reason build system just ignore env vars to not use binutils and binutils-ar, sadly the only way is to use a patch for fix 